### PR TITLE
do not apply timezone to datetime.date

### DIFF
--- a/plann/timespec.py
+++ b/plann/timespec.py
@@ -184,7 +184,8 @@ def parse_timespec(timespec, for_storage=False):
     One timestamp should be accepted, and the second return value will be None.
     """
     ret = _parse_timespec(timespec)
-    if for_storage:
+    # do not try to adjust timezone for datetime.date (all-day events)
+    if for_storage and isinstance(ret[0], datetime.datetime):
         ret = (x and x.astimezone(tz.store_timezone) for x in ret)
     return ret
 


### PR DESCRIPTION
When trying to add some events I was getting errors when using a date without a time. Apparently the date was parsed correctly but when modifying for storage plann tries to adjust the timezone and fails because `datetime.date` has no associated timezone. This workaround avoids the timezone logic for dates.

This means there is no timezone data at all in the generated calendar entry for these events. Do you know if this is an issue? I checked an event created by my calendar app and the `.ics` file also has no timezone information for all-day events.