### PR TITLE
docs: handle links to moved doc

### DIFF
--- a/TASK_MANAGEMENT.md
+++ b/TASK_MANAGEMENT.md
@@ -313,7 +313,7 @@ Those are not much relevant wrg of task handling in plann
 
 ## Daily task management and interactive mode
 
-This is specifically directed towards using plann for daily task management.  See also the [USER GUIDE](USER_GUIDE.md) for more generic user guide.  I will assume that your calendar server needs to support advanced CalDAV queries (see [CALENDAR SERVER RECOMMENDATIONS](CALENDAR_SERVER_RECOMMENDATIONS.md)).
+This is specifically directed towards using plann for daily task management.  See also the [USER GUIDE](USER_GUIDE.md) for more generic user guide.  I will assume that your calendar server needs to support advanced CalDAV queries (see [CALENDAR SERVER RECOMMENDATIONS](docs/ALENDAR_SERVER_RECOMMENDATIONS.md)).
 
 ### Adding tasks
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -32,7 +32,7 @@ Those commands are made mostly for making `plann` more convenient to use for the
 * interactive manage-tasks - go through your tasks and make suggestions
 * interactive update-config - (TODO: NOT IMPLEMENTED YET).  This one is not used by the primary author and is probably under-tested.  Its primary intention is to make it easy for others to use the tool.
 
-Note that many of those commands have only been tested on DAViCal (see the [`CALENDAR_SERVER_RECOMMENDATIONS.md`](CALENDAR_SERVER_RECOMMENDATIONS.md) file)
+Note that many of those commands have only been tested on DAViCal (see the [`docs/ALENDAR_SERVER_RECOMMENDATIONS.md`](CALENDAR_SERVER_RECOMMENDATIONS.md) file)
 
 
 ## Global options


### PR DESCRIPTION
The calendar server recommentations was moved to the docs directory
