### PR TITLE
fix: improved uid filtering ++

### DIFF
--- a/plann/cli.py
+++ b/plann/cli.py
@@ -398,9 +398,10 @@ def ical(ctx, ical_data, ical_file):
         icals = [ ical ]
     for ical in icals:
         for c in ctx.obj['calendars']:
-            ## TODO: this may not be an event - should make a Calendar.save_object method
-            c.save_event(ical)
-
+            ## TODO: there is a TODO-comment in add_object that objclass should not be mandatory.
+            ## when that one has been fixed, remove this additional logic
+            objclass = caldav.Todo if "BEGIN:VTODO" in ical else (caldav.Journal if "BEGIN:VJOURNAL" in ical else caldav.Event)
+            c.add_object(objclass, ical)
 
 @add.command()
 @click.argument('summary', nargs=-1)

--- a/plann/commands.py
+++ b/plann/commands.py
@@ -90,17 +90,10 @@ def __select(ctx, extend_objects=False, all=None, uid=[], abort_on_missing_uid=N
     ## uid(s)
     missing_uids = []
     for uid_ in uid:
-        comp_filter=None
-        if kwargs_['event']:
-            comp_filter='VEVENT'
-        if kwargs_['todo']:
-            comp_filter='VTODO'
-        if kwargs_.get('journal'):
-            comp_filter='VJOURNAL'
         cnt = 0
         for c in ctx.obj['calendars']:
             try:
-                objs.append(c.object_by_uid(uid_, comp_filter=comp_filter))
+                objs.append(c.get_object_by_uid(uid_))
                 cnt += 1
             except caldav.error.NotFoundError:
                 pass

--- a/plann/config.py
+++ b/plann/config.py
@@ -163,7 +163,7 @@ def read_config(fn, interactive_error=False):
                 with open(fn, 'rb') as config_file:
                     return yaml.load(config_file, yaml.Loader)
             except yaml.scanner.ScannerError:
-                logging.error("config file exists but is neither valid json nor yaml.  Check the syntax.")
+                logging.error(f"config file {fn!r} exists but is neither valid json nor yaml.  Check the syntax.")
 
     except FileNotFoundError:
         ## File not found

--- a/plann/lib.py
+++ b/plann/lib.py
@@ -471,7 +471,7 @@ def _set_something(obj, arg, value):
 ## TODO: should be rewritten a bit, we should have a create_list method that does not call on click.echo directly
 ## let the caller decide if click is to be used or not.
 ## Use the yield method to avoid having to generate the full list prior to printing to screen
-def _list(objs, ics=False, template="{DTSTART:?{DUE:?(date missing)?}?%F %H:%M:%S %Z}: {SUMMARY:?{DESCRIPTION:?(no summary given)?}?}", top_down=False, bottom_up=False, indent=0, echo=True, uids=None, filter=lambda obj: obj.icalendar_component.get('STATUS', '') not in ('CANCELLED', 'COMPLETED')):
+def _list(objs, ics=False, template="{DTSTART:?{DUE:?(date missing)?}?%F %H:%M:%S %Z}: {SUMMARY:?{DESCRIPTION:?(no summary given)?}?}", top_down=False, bottom_up=False, indent=0, echo=True, uids=None, filter=lambda obj: True):
     """
     Actual implementation of list
 


### PR DESCRIPTION
When selecting an object by UID, one typically wants the object
without filtering on component type and without filtering away
completed tasks.

Earlier it was often needed to specify `--event` or `--todo` as many
server implementations expects a comp-filter - now the caldav library
has been fixed to work around such server quirks and it's no longer
needed to specify the compfilter when sending the search query to the
server - so the filtering logic has been removed from the UID
filtering.

The list logic would default do client-side filtering to remove
completed tasks, presumably to work around server implementations not
supporting complex queries.  However, now there is workarounds in
place in the caldav library, so this should not be needed anymore.
Said client-side filtering would also kill completed tasks when
searching for a task by UID.

En-passant, a minor TODO-commend was fixed.  Earlier,
`calendar.save_event` would be used when adding components, no matter
if it was an event or not.  Now `calendar.add_object` is used instead.
Unfortunately a new TODO-comment has sneaked in - now we have complex
logic in place to decide the component type, this logic should be
moved to the caldav library.

This changeset was predominantly AI-written.

prompts:

* Please use plann to import this ics-file (...)

* Why can't I look up this thing I just imported by using `plann select --uid=xxx
list` ?

* I think we should just ignore the whole comp_filter-thing when
looking up things by UID. It was needed with complexity here before because
many calendar servers would require the compfilter to be set, however now
the caldav library handles this complexity.

* The client-side filter can most likely be removed. By now the
caldav library does client-side filtering when needed.

Manual work:

* Removed one silly commit adding complexity warning about *potentially* bad data in the .ics-file.
* Completely rewrote a commit dealing with `add_event` being used on tasks
* Squashed the latter into two other commits and rewrote the commit message

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
